### PR TITLE
Fix for new node/io.js versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
+sudo: false
 language: node_js
 node_js:
+  - 'iojs'
+  - "0.12"
   - "0.11"
   - "0.10"
   - "0.8"

--- a/index.js
+++ b/index.js
@@ -6,20 +6,20 @@ var NestedError = function (message, nested) {
     this.nested = nested;
 
     Error.captureStackTrace(this, this.constructor);
-    
+
     var oldStackDescriptor = Object.getOwnPropertyDescriptor(this, 'stack');
 
     Object.defineProperties(this, {
         stack: {
             get: function () {
-                var stack = oldStackDescriptor.get();
+                var stack = oldStackDescriptor.get.call(this);
                 if (this.nested) {
                     stack += '\nCaused By: ' + this.nested.stack;
                 }
                 return stack;
             }
         }
-        
+
     });
 };
 


### PR DESCRIPTION
I don't know if this is intended or not, but newer Versions of node and io.js must have changed the Error object or the `getOwnPropertyDescriptor` function in any way.

It is, `oldStackDescriptor.get()` returns `undefined` because `get()` does not know what the right `this` is, which was easy to fix.

Btw, I think this is the best-crafted project on npm to handle nested errors. Thanks a lot for that.
