### PR TITLE
fix ECMAScript6 compatibility of message property

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: node_js
 node_js:
-  - 'iojs'
+  - "iojs"
   - "0.12"
   - "0.11"
   - "0.10"

--- a/index.js
+++ b/index.js
@@ -2,12 +2,20 @@ var util = require('util');
 
 var NestedError = function (message, nested) {
     Error.call(this);
-    this.message = message;
     this.nested = nested;
 
     Error.captureStackTrace(this, this.constructor);
 
     var oldStackDescriptor = Object.getOwnPropertyDescriptor(this, 'stack');
+
+    if (typeof message !== 'undefined') {
+        Object.defineProperty(this, 'message', {
+            value: message,
+            writable: true,
+            enumerable: false,
+            configurable: true
+        });
+    }
 
     Object.defineProperties(this, {
         stack: {

--- a/test.js
+++ b/test.js
@@ -4,7 +4,7 @@ var uuid = require('uuid');
 var util = require('util');
 
 describe('NestedErrors', function ()  {
-    
+
     it('are instances of Error', function () {
         var error = new NestedError();
         expect(error).to.be.an.instanceOf(Error);
@@ -14,27 +14,27 @@ describe('NestedErrors', function ()  {
     it('include message in stacktrace', function () {
         var message = uuid.v1();
         var nested = new NestedError(message);
-        
+
         expect(nested.stack).to.contain(message);
     });
 
     it('includes child stack in stacktrace', function () {
         var childMessage = uuid.v1();
         var child = new Error(childMessage);
-        
+
         var message = uuid.v1();
         var nested = new NestedError(message, child);
-        
+
         expect(nested.stack).to.contain('Caused By: ' + child.stack);
     });
-    
+
     it('allows multiple nested errors', function () {
         var childMessage = uuid.v1();
         var child = new Error(childMessage);
 
         var child2Message = uuid.v1();
         var child2 = new NestedError(child2Message, child);
-        
+
         var message = uuid.v1();
         var nested = new NestedError(message, child2);
 
@@ -47,7 +47,7 @@ describe('NestedErrors', function ()  {
         };
         util.inherits(SubclassError, NestedError);
         SubclassError.prototype.name = 'SubclassError';
-        
+
         var message = uuid.v1();
         var error = new SubclassError(message);
         expect(error.stack).to.contain('SubclassError');
@@ -60,14 +60,30 @@ describe('NestedErrors', function ()  {
         };
         util.inherits(SubclassError, NestedError);
         SubclassError.prototype.name = 'SubclassError';
-        
+
         var childMessage = uuid.v1();
         var child = new Error(childMessage);
-        
+
         var message = uuid.v1();
         var error = new SubclassError(message, child);
 
         expect(error.stack).to.contain('Caused By: ' + child.stack);
     });
-    
+
+    it('messages are ECMAScript6 compatible', function () {
+        var nested = new NestedError(uuid.v1());
+        var messageDescriptor = Object.getOwnPropertyDescriptor(nested, 'message');
+
+        expect(messageDescriptor.writable).to.be.equal(true);
+        expect(messageDescriptor.enumerable).to.be.equal(false);
+        expect(messageDescriptor.configurable).to.be.equal(true);
+    });
+
+    it('without messages are ECMAScript6 compatible', function () {
+        var nested = new NestedError();
+        var messageDescriptor = Object.getOwnPropertyDescriptor(nested, 'message');
+
+        expect(messageDescriptor).to.be.undefined;
+    });
+
 });


### PR DESCRIPTION
ECMAScript6 defines [Error::message](http://people.mozilla.org/~jorendorff/es6-draft.html#sec-error-message)s as properties which are:

> {[[Value]]: msg, [[Writable]]: true, [[Enumerable]]: false, [[Configurable]]: true}

The "[[Enumerable]]: false" part is important for me, because I want to use `NestedError` in combination with ECMAScript6s Object.assign (or more precisely [object-assign](https://github.com/sindresorhus/object-assign)), which does not (and should not) copy non-enumerable attributes.
