### PR TITLE
Only call captureStackTrace in environments that have it

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,10 +1,11 @@
+var captureStackTrace = require('capture-stack-trace');
 var inherits = require('inherits');
 
 var NestedError = function (message, nested) {
     Error.call(this);
     this.nested = nested;
 
-    Error.captureStackTrace(this, this.constructor);
+    captureStackTrace(this, this.constructor);
 
     var oldStackDescriptor = Object.getOwnPropertyDescriptor(this, 'stack');
 

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "author": "Matt Lavin <matt.lavin@gmail.com>",
   "license": "MIT",
   "dependencies": {
+    "capture-stack-trace": "~1.0.0",
     "inherits": "~2.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Only V8 environments define it, so no Safari/IE/Firefox
