### PR TITLE
Remove useless call to Error.call()

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 var inherits = require('inherits');
 
 var NestedError = function (message, nested) {
-    Error.call(this);
     this.nested = nested;
 
     Error.captureStackTrace(this, this.constructor);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nested-error-stacks",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "An Error subclass that will chain nested Errors and dump nested stacktraces",
   "bugs": {
     "url": "https://github.com/mdlavin/nested-error-stacks/issues"


### PR DESCRIPTION
After reading https://gist.github.com/justmoon/15511f92e5216fa2624b and running the tests, I found it was possible to remove the call to Error.call() without breaking any function.
