### PR TITLE
Fixes #12: Work around Bluebird long stack traces chomping 'Caused by'

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,3 +58,12 @@ function MyError(message, nested) {
 util.inherits(MyError, NestedError);
 MyError.prototype.name = 'MyError';
 ```
+
+Bluebird long stack trace support
+---------------------------------
+
+By default, when bluebird long stack traces are enabled, any stack trace lines
+that don't begin with 'at' will get removed. To work around this, 'at ' is
+prepended to 'Caused By:...' if any of the environment variables
+BLUEBIRD_LONG_STACK_TRACES=\<truthy\>, BLUEBIRD_DEBUG=\<truthy\>, or
+NODE_ENV=development are set.

--- a/index.js
+++ b/index.js
@@ -35,9 +35,22 @@ function buildStackDescriptor(oldStackDescriptor, nested) {
 }
 
 function buildCombinedStacks(stack, nested) {
-    if (nested) {
-        stack += '\nCaused By: ' + nested.stack;
+    if (!nested) {
+        return stack;
     }
+
+    stack += '\n';
+
+    // Bluebird long stack traces will drop any
+    // trace lines that don't match /^\s*at\s*/
+    // see https://github.com/mdlavin/nested-error-stacks/issues/12
+    if (process.env.BLUEBIRD_DEBUG ||
+        process.env.BLUEBIRD_LONG_STACK_TRACES ||
+        process.env.NODE_ENV === 'development') {
+        stack += 'at ';
+    }
+
+    stack += 'Caused By: ' + nested.stack;
     return stack;
 }
 

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "inherits": "~2.0.1"
   },
   "devDependencies": {
+    "bluebird": "^3.5.0",
     "chai": "^3.5.0",
     "eslint": "^3.9.1",
     "mocha": "^3.1.2",


### PR DESCRIPTION
Prepend 'at' so that 'Caused By...' doesn't get removed by Bluebird's long stack traces, but only when associated environment variables are enabled. See http://bluebirdjs.com/docs/api/environment-variables.html

